### PR TITLE
Fixed: None in train_data_directory is seen as a string

### DIFF
--- a/config/melgan/data_config.yaml
+++ b/config/melgan/data_config.yaml
@@ -1,7 +1,7 @@
 # PATHS: change accordingly
 data_directory: '/path/to/dataset' # path to wavs and metafile directory
 log_directory: '/path/to/logdir'   # weights and logs are stored here
-train_data_directory: None         # optional: alternative directory where to store processed data (default is data_dir)
+train_data_directory:              # optional: alternative directory where to store processed data (default is data_dir)
 wav_subdir_name: 'wavs'            # subfolder in data_directory containing wavs files
 metadata_filename: 'metadata.csv'  # name of metadata file under data_directory
 session_name: None                 # session naming, can be specified in command line


### PR DESCRIPTION
Changed it to be empty, because passing "None" doesn't equal type of None